### PR TITLE
Add cached rank id for MPI particle exchange

### DIFF
--- a/src/particle_exchanger.cpp
+++ b/src/particle_exchanger.cpp
@@ -5,7 +5,7 @@ void create_Mpi_RemoteParticleType(MPI_Datatype &dtype)
 {
   /*to create the struct data type for communication*/
   RemoteParticle_t p;
-#define NumAttr 10
+#define NumAttr 11
   MPI_Datatype oldtypes[NumAttr];
   int blockcounts[NumAttr];
   MPI_Aint offsets[NumAttr], origin, extent;
@@ -34,6 +34,7 @@ void create_Mpi_RemoteParticleType(MPI_Datatype &dtype)
 #endif
   RegisterAttr(Type, MPI_INT, 1);
 #endif
+  RegisterAttr(RankId, MPI_UNSIGNED_SHORT, 1);
   RegisterAttr(Order, MPI_HBT_INT, 1);
 #undef RegisterAttr
   assert(i <= NumAttr);

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -142,7 +142,7 @@ void Particle_t::create_MPI_type(MPI_Datatype &dtype)
 {
   /*to create the struct data type for communication*/
   Particle_t &p = *this;
-#define MaxNumAttr 10
+#define MaxNumAttr 11
   MPI_Datatype oldtypes[MaxNumAttr];
   MPI_Aint offsets[MaxNumAttr], origin, extent;
   int blockcounts[MaxNumAttr];
@@ -171,6 +171,7 @@ void Particle_t::create_MPI_type(MPI_Datatype &dtype)
 #endif
   RegisterAttr(Type, MPI_INT, 1);
 #endif
+  RegisterAttr(RankId, MPI_UNSIGNED_SHORT, 1);
 #undef RegisterAttr
   assert(i <= MaxNumAttr);
 

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -2,6 +2,7 @@
 #define SNAPSHOT_H_INCLUDED
 
 #include <assert.h>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
@@ -11,6 +12,7 @@
 #include "config_parser.h"
 #include "datatypes.h"
 #include "hash.h"
+#include "hash_integers.h"
 #include "mpi_wrapper.h"
 #include "mymath.h"
 #include "snapshot_number.h"
@@ -71,11 +73,16 @@ struct Particle_t
 #endif
   ParticleType_t Type;
 #endif
+  uint16_t RankId = 0;
   HBTInt HostId;
   void create_MPI_type(MPI_Datatype &dtype);
-  Particle_t(){};
-  Particle_t(HBTInt id) : Id(id)
+  Particle_t() = default;
+  Particle_t(HBTInt id) : Id(id), RankId(0)
   {
+  }
+  void SetRankFromIdHash(int comm_size)
+  {
+    RankId = static_cast<uint16_t>(RankFromIdHash(Id, comm_size));
   }
   bool operator==(const Particle_t &other) const
   {


### PR DESCRIPTION
## Summary
- add a RankId cache to `Particle_t` and expose a helper to populate it from `RankFromIdHash`
- include the cached rank in the MPI datatype descriptions for local and remote particles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8a64b4dc8324943e98e496745e87