### PR TITLE
Ensure RankId cached for loaded particles

### DIFF
--- a/src/io/apostle_io.cpp
+++ b/src/io/apostle_io.cpp
@@ -69,6 +69,14 @@ void ApostleReader_t::SetSnapshot(int snapshotId)
     SnapshotName = HBTConfig.SnapshotNameList[snapshotId];
 }
 
+void ApostleReader_t::AssignRankIds(Particle_t *particles, HBTInt count)
+{
+  if (count <= 0)
+    return;
+  for (HBTInt i = 0; i < count; i++)
+    particles[i].SetRankFromIdHash(comm_size);
+}
+
 void ApostleReader_t::GetFileName(int ifile, string &filename)
 {
   string subname = SnapshotName;
@@ -197,6 +205,7 @@ void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
       ReadDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data());
       for (int i = 0; i < np; i++)
         ParticlesThisType[i].Id = id[i];
+      AssignRankIds(ParticlesThisType, static_cast<HBTInt>(np));
     }
 
     // mass
@@ -301,6 +310,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
         ReadDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data());
         for (int i = 0; i < np; i++)
           ParticlesThisType[i].Id = id[i];
+        AssignRankIds(ParticlesThisType, static_cast<HBTInt>(np));
       }
 
       // mass
@@ -361,6 +371,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
 void ApostleReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<Particle_t> &Particles,
                                    Cosmology_t &Cosmology)
 {
+  comm_size = world.size();
   SetSnapshot(snapshotId);
 
   const int root = 0;
@@ -419,6 +430,7 @@ inline bool CompParticleHost(const ParticleHost_t &a, const ParticleHost_t &b)
 
 void ApostleReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo_t> &Halos)
 { // read in particle properties at the same time, to avoid particle look-up at later stage.
+  comm_size = world.size();
   SetSnapshot(snapshotId);
 
   const int root = 0;

--- a/src/io/apostle_io.h
+++ b/src/io/apostle_io.h
@@ -43,6 +43,7 @@ class ApostleReader_t
   vector<HBTInt> np_file;
   vector<HBTInt> offset_file;
   ApostleHeader_t Header;
+  int comm_size = 1;
   void ReadHeader(int ifile, ApostleHeader_t &header);
   HBTInt CompileFileOffsets(int nfiles);
   void ReadSnapshot(int ifile, Particle_t *ParticlesInFile);
@@ -50,6 +51,7 @@ class ApostleReader_t
   void GetFileName(int ifile, string &filename);
   void SetSnapshot(int snapshotId);
   void GetParticleCountInFile(hid_t file, int np[]);
+  void AssignRankIds(Particle_t *particles, HBTInt count);
 
   MPI_Datatype MPI_ApostleHeader_t;
 

--- a/src/io/gadget_io.cpp
+++ b/src/io/gadget_io.cpp
@@ -60,12 +60,20 @@ void GadgetHeader_t::create_MPI_type(MPI_Datatype &dtype)
 
 GadgetReader_t::GadgetReader_t(MpiWorker_t &world, int snapshot_id, vector<Particle_t> &particles,
                                Cosmology_t &cosmology)
-  : SnapshotId(snapshot_id), Particles(particles), Cosmology(cosmology), Header()
+  : Particles(particles), Cosmology(cosmology), comm_size(world.size()), SnapshotId(snapshot_id), Header()
 {
   NeedByteSwap = false;
   IntTypeSize = 0;
   RealTypeSize = 0;
   Load(world);
+}
+
+void GadgetReader_t::AssignRankIds(Particle_t *particles, HBTInt count)
+{
+  if (count <= 0)
+    return;
+  for (HBTInt i = 0; i < count; i++)
+    particles[i].SetRankFromIdHash(comm_size);
 }
 
 #define myfread(buf, size, count, fp) fread_swap(buf, size, count, fp, NeedByteSwap)
@@ -359,8 +367,9 @@ void GadgetReader_t::ReadGadgetFile(int iFile)
   vector<HBTInt> offset(TypeMax);
   CompileOffsets(begin(header.npart), end(header.npart), offset.begin());
 
-  Particles.resize(Particles.size() + n_read);
-  const auto NewParticles = Particles.end() - n_read;
+  auto old_size = Particles.size();
+  Particles.resize(old_size + n_read);
+  auto NewParticles = Particles.data() + old_size;
 
   if (RealTypeSize == 4)
   {
@@ -393,12 +402,15 @@ void GadgetReader_t::ReadGadgetFile(int iFile)
     }
     else
       ReadScalarBlock(long, Id)
+
+    AssignRankIds(NewParticles, static_cast<HBTInt>(n_read));
   }
   else
   {
     HBTInt id_now = OffsetOfParticleInFiles[iFile];
     for (HBTInt i = 0; i < n_read; i++)
       NewParticles[i].Id = id_now + i;
+    AssignRankIds(NewParticles, static_cast<HBTInt>(n_read));
   }
 
 #define MassDataPresent(i) ((0 == header.mass[i]) && (header.npartTotal[i]))

--- a/src/io/gadget_io.h
+++ b/src/io/gadget_io.h
@@ -29,6 +29,7 @@ class GadgetReader_t
   vector<Particle_t> &Particles;
   Cosmology_t &Cosmology;
 
+  int comm_size;
   int SnapshotId;
   GadgetHeader_t Header;
   bool NeedByteSwap;
@@ -42,6 +43,7 @@ class GadgetReader_t
   HBTInt ReadGadgetNumberOfParticles(int ifile);
   void GetGadgetFileName(int ifile, string &filename);
   void Load(MpiWorker_t &world);
+  void AssignRankIds(Particle_t *particles, HBTInt count);
 
 public:
   GadgetReader_t(MpiWorker_t &world, int snapshot_id, vector<Particle_t> &particles, Cosmology_t &cosmology);

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -82,6 +82,14 @@ void SwiftSimReader_t::SetSnapshot(int snapshotId)
     SnapshotName = HBTConfig.SnapshotNameList[snapshotId];
 }
 
+void SwiftSimReader_t::AssignRankIds(Particle_t *particles, HBTInt count)
+{
+  if (count <= 0)
+    return;
+  for (HBTInt i = 0; i < count; i++)
+    particles[i].SetRankFromIdHash(comm_size);
+}
+
 void SwiftSimReader_t::GetFileName(int ifile, string &filename)
 {
   stringstream formatter;
@@ -377,6 +385,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         ReadPartialDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data(), offset + read_offset, count);
         for (hsize_t i = 0; i < count; i += 1)
           ParticlesToRead[offset + i].Id = id[i];
+        AssignRankIds(ParticlesToRead + offset, static_cast<HBTInt>(count));
       }
     }
 
@@ -567,6 +576,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
           ReadPartialDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data(), offset + read_offset, count);
           for (hsize_t i = 0; i < count; i += 1)
             ParticlesToRead[offset + i].Id = id[i];
+          AssignRankIds(ParticlesToRead + offset, static_cast<HBTInt>(count));
         }
       }
 
@@ -647,6 +657,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
 void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<Particle_t> &Particles,
                                     Cosmology_t &Cosmology)
 {
+  comm_size = world.size();
 
   MPI_Barrier(world.Communicator);
 
@@ -827,6 +838,7 @@ inline bool CompParticleHost(const Particle_t &a, const Particle_t &b)
 
 void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo_t> &Halos)
 { // read in particle properties at the same time, to avoid particle look-up at later stage.
+  comm_size = world.size();
   SetSnapshot(snapshotId);
 
   // Decide how many ranks per node read simultaneously

--- a/src/io/swiftsim_io.h
+++ b/src/io/swiftsim_io.h
@@ -46,6 +46,7 @@ class SwiftSimReader_t
   vector<HBTInt> np_file;
   vector<HBTInt> offset_file;
   SwiftSimHeader_t Header;
+  int comm_size = 1;
   hid_t OpenFile(int ifile);
   void ReadHeader(int ifile, SwiftSimHeader_t &header);
   void ReadUnits(HBTReal &MassInMsunh, HBTReal &LengthInMpch, HBTReal &VelInKmS);
@@ -56,6 +57,7 @@ class SwiftSimReader_t
   void GetFileName(int ifile, string &filename);
   void SetSnapshot(int snapshotId);
   void GetParticleCountInFile(hid_t file, HBTInt np[]);
+  void AssignRankIds(Particle_t *particles, HBTInt count);
 
   /* To load information about particle splits */
   void GetParticleSplitFileName(int snapshotId, string &filename);


### PR DESCRIPTION
## Summary
- track the MPI communicator size inside the Gadget, SwiftSim, and Apostle readers
- populate Particle_t::RankId immediately after reading or synthesizing IDs for snapshot and group-particle data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9589859c8324be8a9c10d1ae572a