### PR TITLE
Set RankId when loading group particle data

### DIFF
--- a/src/io/apostle_io.cpp
+++ b/src/io/apostle_io.cpp
@@ -309,8 +309,10 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
         vector<HBTInt> id(np);
         ReadDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data());
         for (int i = 0; i < np; i++)
+        {
           ParticlesThisType[i].Id = id[i];
-        AssignRankIds(ParticlesThisType, static_cast<HBTInt>(np));
+          ParticlesThisType[i].SetRankFromIdHash(comm_size);
+        }
       }
 
       // mass

--- a/src/io/gadget_group_io.cpp
+++ b/src/io/gadget_group_io.cpp
@@ -447,6 +447,7 @@ void Load(MpiWorker_t &world, int SnapshotId, vector<Halo_t> &Halos)
   }
 
   /* populate haloes*/
+  const int comm_size = world.size();
   Halos.resize(thistask.nhalo);
   auto p = ParticleBuffer.data();
   for (HBTInt i = 0; i < Halos.size(); i++)
@@ -454,7 +455,10 @@ void Load(MpiWorker_t &world, int SnapshotId, vector<Halo_t> &Halos)
     Halos[i].HaloId = thistask.haloid_begin + i;
     Halos[i].Particles.resize(HaloLenBuffer[i]);
     for (HBTInt j = 0; j < HaloLenBuffer[i]; j++)
+    {
       Halos[i].Particles[j].Id = *(p++);
+      Halos[i].Particles[j].SetRankFromIdHash(comm_size);
+    }
   }
 
   //   HBTInt np_node=0;

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -139,6 +139,7 @@ void SubhaloSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, const SubRe
     return;
   }
   SetSnapshotIndex(snapshot_index);
+  comm_size = world.size();
 
   int NumberOfFiles;
   HBTInt TotNumberOfSubs;
@@ -259,6 +260,8 @@ void SubhaloSnapshot_t::ReadFile(int iFile, const SubReaderDepth_t depth)
         HBTInt *p = (HBTInt *)(vl[i].p);
         for (HBTInt j = 0; j < vl[i].len; j++)
           NewSubhalos[i].Particles[j].Id = p[j];
+        for (auto &particle : NewSubhalos[i].Particles)
+          particle.SetRankFromIdHash(comm_size);
       }
       ReclaimVlenData(dset, H5T_HBTIntArr, vl.data());
       H5Dclose(dset);

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -575,8 +575,10 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
           vector<HBTInt> id(count);
           ReadPartialDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data(), offset + read_offset, count);
           for (hsize_t i = 0; i < count; i += 1)
+          {
             ParticlesToRead[offset + i].Id = id[i];
-          AssignRankIds(ParticlesToRead + offset, static_cast<HBTInt>(count));
+            ParticlesToRead[offset + i].SetRankFromIdHash(comm_size);
+          }
         }
       }
 

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -272,6 +272,7 @@ private:
   bool ParallelizeHaloes;
   hid_t H5T_SubhaloInMem, H5T_SubhaloInDisk;
   MPI_Datatype MPI_HBT_SubhaloShell_t; // MPI datatype ignoring the particle list
+  int comm_size = 1;
 
   void RegisterNewTracks(MpiWorker_t &world);
   void DecideCentrals(const HaloSnapshot_t &halo_snap);


### PR DESCRIPTION
## Summary
- ensure gadget group particles compute RankId as they are populated
- set RankId for SwiftSim and Apostle group particle reads using the existing helper
- persist MPI communicator size in subhalo snapshots and apply it when rebuilding particle lists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd99f3e44c832493bcd83cea79319c