### PR TITLE
Ensure particle rank metadata stays in sync with ID changes

### DIFF
--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -118,6 +118,24 @@ void ExchangeSubHalos(MpiWorker_t &world, vector<Subhalo_t> &InHalos, vector<Sub
     */
 }
 
+void SubhaloSnapshot_t::ResetParticleRankId(Particle_t &particle) const
+{
+  if (particle.Id == SpecialConst::NullParticleId)
+  {
+    particle.RankId = std::numeric_limits<uint16_t>::max();
+    return;
+  }
+
+  if (comm_size > 0)
+  {
+    particle.SetRankFromIdHash(comm_size);
+  }
+  else
+  {
+    particle.RankId = std::numeric_limits<uint16_t>::max();
+  }
+}
+
 void SubhaloSnapshot_t::BuildMPIDataType()
 {
   /*to create the struct data type for communication*/
@@ -200,6 +218,7 @@ void SubhaloSnapshot_t::BuildMPIDataType()
 
 void SubhaloSnapshot_t::UpdateParticles(MpiWorker_t &world, const ParticleSnapshot_t &snapshot)
 {
+  comm_size = world.size();
   /* We need to split particles here, since ExchangeSubHalos updates the particle information of
    * subhaloes based on the Particle IDs present in the Particle vector when it is called.*/
 #ifndef DM_ONLY
@@ -233,6 +252,16 @@ void SubhaloSnapshot_t::UpdateSplitParticles(const ParticleSnapshot_t &snapshot)
 
         Particle_t new_particle;
         new_particle.Id = new_id;
+
+        const HBTInt new_index = snapshot.GetIndex(new_id);
+        if (new_index != SpecialConst::NullParticleId)
+        {
+          new_particle.RankId = snapshot.Particles[new_index].RankId;
+        }
+        else
+        {
+          ResetParticleRankId(new_particle);
+        }
 
         Subhalos[sub_number].Particles.push_back(new_particle);
       }

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -281,6 +281,8 @@ private:
   void BuildMPIDataType();
   void PurgeMostBoundParticles();
 
+  void ResetParticleRankId(Particle_t &particle) const;
+
   /* I/O methods */
   void ReadFile(int iFile, const SubReaderDepth_t depth);
   void WriteBoundFiles(MpiWorker_t &world, const int &number_ranks_writing);

--- a/src/subhalo_reassign_gas.cpp
+++ b/src/subhalo_reassign_gas.cpp
@@ -170,6 +170,7 @@ void SubhaloSnapshot_t::ReassignParticles(MpiWorker_t &world, HaloSnapshot_t &ha
                               Subhalos[ngb_subid].Particles.push_back(part);
                               // Flag the particle for removal from this subhalo
                               part.Id = SpecialConst::NullParticleId;
+                              ResetParticleRankId(part);
                               nr_reassigned += 1;
                             }
                         }

--- a/src/subhalo_update_mostbound.cpp
+++ b/src/subhalo_update_mostbound.cpp
@@ -15,6 +15,7 @@
 */
 void SubhaloSnapshot_t::UpdateMostBoundPosition(MpiWorker_t &world, const ParticleSnapshot_t &part_snap)
 {
+  comm_size = world.size();
   // Count local subhalos which have zero particles
   HBTInt nr_zero = 0;
   for (auto &&sub : Subhalos)
@@ -40,6 +41,7 @@ void SubhaloSnapshot_t::UpdateMostBoundPosition(MpiWorker_t &world, const Partic
       ZeroSizeSubhalo[nr_zero] = sub;
       ZeroSizeSubhalo[nr_zero].Particles.resize(1);
       ZeroSizeSubhalo[nr_zero].Particles[0] = Particle_t(sub.MostBoundParticleId);
+      ResetParticleRankId(ZeroSizeSubhalo[nr_zero].Particles[0]);
 #ifndef NDEBUG
       // In Debug mode ParticleExchanger_t::QueryParticles() will fail an
       // assert() if any tracer particle is not found. Here we set Type=TypeMax


### PR DESCRIPTION
## Summary
- add a helper that refreshes a particle RankId when an Id changes and reuse it across subhalo workflows
- copy or recompute RankId for newly spawned particles and zero-particle subhalos so exchanges route correctly
- clear cached RankId when gas reassignment nulls particle Ids to avoid stale routing data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9f1c4600832491145a4946613989