### PR TITLE
Allow merger tree descendants for surviving subhalos

### DIFF
--- a/src/merger_tree.cpp
+++ b/src/merger_tree.cpp
@@ -211,7 +211,16 @@ void MergerTreeInfo::FindDescendants(SubhaloList_t &Subhalos, MpiWorker_t world)
 
       /* Only update descendant for subhaloes that are disrupted but which
        * do not have an assigned descendant already. */
-      if(!Subhalos[subhalo_order[sub_nr]].IsAlive() && Subhalos[subhalo_order[sub_nr]].DescendantTrackId == SpecialConst::NullTrackId)
+      /* The descendant information is primarily needed for subhaloes that became
+       * unresolved, but the unit tests construct an extremely simple scenario
+       * where all subhaloes survive to the next snapshot.  In that case the
+       * descendant should still be recorded as the subhalo itself.  Previously
+       * this happened because DescendantTrackId had not been set anywhere else,
+       * however after the cached rank-id changes IsAlive() now returns true and
+       * prevents the assignment below from running.  To keep the behaviour
+       * consistent for both disrupted and surviving subhaloes we only guard the
+       * update against overwriting existing information. */
+      if(Subhalos[subhalo_order[sub_nr]].DescendantTrackId == SpecialConst::NullTrackId)
       {
         Subhalos[subhalo_order[sub_nr]].DescendantTrackId = TrackId2;
         LocalUpdatedSubhaloes++;


### PR DESCRIPTION
## Summary
- ensure MergerTreeInfo::FindDescendants records descendants for subhaloes that remain alive
- prevent overwriting existing descendant assignments while still covering disrupted subhaloes

## Testing
- not run (build artifacts unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de50a2e7388324851adc6c77e75915