### PR TITLE
Include new particle indices in MPI datatypes

### DIFF
--- a/src/particle_exchanger.cpp
+++ b/src/particle_exchanger.cpp
@@ -5,7 +5,7 @@ void create_Mpi_RemoteParticleType(MPI_Datatype &dtype)
 {
   /*to create the struct data type for communication*/
   RemoteParticle_t p;
-#define NumAttr 10
+#define NumAttr 14
   MPI_Datatype oldtypes[NumAttr];
   int blockcounts[NumAttr];
   MPI_Aint offsets[NumAttr], origin, extent;
@@ -24,6 +24,9 @@ void create_Mpi_RemoteParticleType(MPI_Datatype &dtype)
     i++;                                                                                                               \
   }
   RegisterAttr(Id, MPI_HBT_INT, 1);
+  RegisterAttr(CoreIndex, MPI_UINT8_T, 1);
+  RegisterAttr(RankIndex, MPI_UINT8_T, 1);
+  RegisterAttr(LocalIndex, MPI_UINT32_T, 1);
   RegisterAttr(HostId, MPI_HBT_INT, 1);
   RegisterAttr(ComovingPosition, MPI_HBT_REAL, 3);
   RegisterAttr(PhysicalVelocity, MPI_HBT_VEL, 3);

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -142,7 +142,7 @@ void Particle_t::create_MPI_type(MPI_Datatype &dtype)
 {
   /*to create the struct data type for communication*/
   Particle_t &p = *this;
-#define MaxNumAttr 10
+#define MaxNumAttr 13
   MPI_Datatype oldtypes[MaxNumAttr];
   MPI_Aint offsets[MaxNumAttr], origin, extent;
   int blockcounts[MaxNumAttr];
@@ -161,6 +161,9 @@ void Particle_t::create_MPI_type(MPI_Datatype &dtype)
     i++;                                                                                                               \
   }
   RegisterAttr(Id, MPI_HBT_INT, 1);
+  RegisterAttr(CoreIndex, MPI_UINT8_T, 1);
+  RegisterAttr(RankIndex, MPI_UINT8_T, 1);
+  RegisterAttr(LocalIndex, MPI_UINT32_T, 1);
   RegisterAttr(HostId, MPI_HBT_INT, 1);
   RegisterAttr(ComovingPosition, MPI_HBT_REAL, 3);
   RegisterAttr(PhysicalVelocity, MPI_HBT_VEL, 3);


### PR DESCRIPTION
## Summary
- include the new particle index fields in the MPI datatype built from Particle_t
- update the remote particle MPI datatype to carry the same bookkeeping fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690365d5427c832491584d23c5d7ed6b